### PR TITLE
Fix typo in install instructions

### DIFF
--- a/examples/dynamic.ipynb
+++ b/examples/dynamic.ipynb
@@ -12,7 +12,7 @@
     "- `scipy`\n",
     "- `xarray-leaflet`\n",
     "\n",
-    "The recommended way is: `conda install -c conda-forge requests tqdm matplotlib scipy xarray-leaflet`\n",
+    "The recommended way is: `conda install -c conda-forge requests tqdm matplotlib scipy xarray_leaflet`\n",
     "\n",
     "Note: you can replace `conda` with [mamba](https://github.com/QuantStack/mamba) if you don't like to wait ;-)"
    ]

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -10,7 +10,7 @@
     "- `tqdm`\n",
     "- `xarray-leaflet`\n",
     "\n",
-    "The recommended way is: `conda install -c conda-forge requests tqdm xarray-leaflet`\n",
+    "The recommended way is: `conda install -c conda-forge requests tqdm xarray_leaflet`\n",
     "\n",
     "Note: you can replace `conda` with [mamba](https://github.com/QuantStack/mamba) if you don't like to wait ;-)"
    ]


### PR DESCRIPTION
Hi! It seems there was a typo in the install instructions: `xarray-leaflet`instead of `xarray_leaflet`.