### PR TITLE
Update binder link for master —> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/davidbrochart/xarray_leaflet/master?urlpath=lab%2Ftree%2Fexamples%2Fintroduction.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/davidbrochart/xarray_leaflet/main?urlpath=lab%2Ftree%2Fexamples%2Fintroduction.ipynb)
 [![Build Status](https://github.com/davidbrochart/xarray_leaflet/workflows/UI%20Tests/badge.svg)](https://github.com/davidbrochart/xarray_leaflet/actions)
 
 # xarray-leaflet: an xarray extension for tiled map plotting


### PR DESCRIPTION
Hi there, cool package. I noticed when launching the binder that the link wasn't updated for the switch from `master` to `main`. There are a few other links w/ `master` but they seem to be redirected by GitHub — just not this one. Cheers.