### PR TITLE
mask nan in single band raster

### DIFF
--- a/xarray_leaflet/xarray_leaflet.py
+++ b/xarray_leaflet/xarray_leaflet.py
@@ -392,7 +392,9 @@ class LeafletMap(HasTraits):
                         da_tile = np.stack(das, axis=2)
                         write_image(path, da_tile, self.persist)
                     else:
-                        da_tile = self.colormap(das[0])
+                        alpha = np.where(np.isnan(das[0]), 0, 1) 
+                        da_tile = self.colormap(das[0])                        
+                        da_tile[:,:,3:] = np.expand_dims(alpha, axis=2)
                         write_image(path, da_tile*255, self.persist)
 
         if self.dynamic:


### PR DESCRIPTION
Fix #62 

I computed the alpha channel as it is done for rgb images. 
My assomption is that single band dataset will always use `np.nan` as a nodata value. 

At first I wanted to use:
```python
alpha = np.where(das[0]==self._da.rio.nodata, 0, 1)
```

but if `nodata` is `np.nan` it always returns 1. If you know a trick that could work for any value + `np.nan` that would be great. if not, the assumption I made seems to be commonly accepted. e.g @giswqs use the same in the `add_raster` method of `geemap`: https://github.com/giswqs/geemap/blob/13c83f59ebc6790b531277c5908859d4cb5ec190/geemap/geemap.py#L3526
 